### PR TITLE
Reintroduce burial_depth fields until okada_wrapper is replaced

### DIFF
--- a/mocha/tests/FileOpenerTests.spec.ts
+++ b/mocha/tests/FileOpenerTests.spec.ts
@@ -99,7 +99,7 @@ describe('File Openers Work as Expected', () => {
 	it('Can Open Segment Files Properly', async () => {
 		const directoryStructure = {
 			root: {
-				'segment.csv': `name,lon1,lat1,lon2,lat2,dip,res,other3,other6,other7,other8,other9,other10,other11,create_ribbon_mesh,locking_depth,locking_depth_sig,locking_depth_flag,dip_sig,dip_flag,ss_rate,ss_rate_sig,ss_rate_flag,ds_rate,ds_rate_sig,ds_rate_flag,ts_rate,ts_rate_sig,ts_rate_flag,resolution_override,resolution_other,patch_file_name,patch_flag,patch_slip_file,patch_slip_flag,ss_rate_bound_flag,ss_rate_bound_min,ss_rate_bound_max,ds_rate_bound_flag,ds_rate_bound_min,ds_rate_bound_max,ts_rate_bound_flag,ts_rate_bound_min,ts_rate_bound_max,
+				'segment.csv': `name,lon1,lat1,lon2,lat2,dip,res,other3,other6,other7,other8,other9,other10,other11,create_ribbon_mesh,locking_depth,locking_depth_sig,locking_depth_flag,dip_sig,dip_flag,ss_rate,ss_rate_sig,ss_rate_flag,ds_rate,ds_rate_sig,ds_rate_flag,ts_rate,ts_rate_sig,ts_rate_flag,burial_depth,burial_depth_sig,burial_depth_flag,resolution_override,resolution_other,patch_file_name,patch_flag,patch_slip_file,patch_slip_flag,ss_rate_bound_flag,ss_rate_bound_min,ss_rate_bound_max,ds_rate_bound_flag,ds_rate_bound_min,ds_rate_bound_max,ts_rate_bound_flag,ts_rate_bound_min,ts_rate_bound_max,
 BRa                                                                ,247.087,43.873,247.764,42.286,90,100,0,0,0,0,0,0,0,0,15,5,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1.0,1.0,0,-1.0,1.0,0,-1.0,1.0,
 BRb                                                                ,245.927,44.722,247.087,43.873,90,100,0,0,0,0,0,0,0,0,15,5,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1.0,1.0,0,-1.0,1.0,0,-1.0,1.0,`
 			}
@@ -121,7 +121,7 @@ BRb                                                                ,245.927,44.7
 	it('Can Write Segment Files Properly', async () => {
 		const directoryStructure = {
 			root: {
-				'segment.csv': `name,lon1,lat1,lon2,lat2,dip,res,other3,other6,other7,other8,other9,other10,other11,create_ribbon_mesh,locking_depth,locking_depth_sig,locking_depth_flag,dip_sig,dip_flag,ss_rate,ss_rate_sig,ss_rate_flag,ds_rate,ds_rate_sig,ds_rate_flag,ts_rate,ts_rate_sig,ts_rate_flag,resolution_override,resolution_other,patch_file_name,patch_flag,patch_slip_file,patch_slip_flag,ss_rate_bound_flag,ss_rate_bound_min,ss_rate_bound_max,ds_rate_bound_flag,ds_rate_bound_min,ds_rate_bound_max,ts_rate_bound_flag,ts_rate_bound_min,ts_rate_bound_max`
+				'segment.csv': `name,lon1,lat1,lon2,lat2,dip,res,other3,other6,other7,other8,other9,other10,other11,create_ribbon_mesh,locking_depth,locking_depth_sig,locking_depth_flag,dip_sig,dip_flag,ss_rate,ss_rate_sig,ss_rate_flag,ds_rate,ds_rate_sig,ds_rate_flag,ts_rate,ts_rate_sig,ts_rate_flag,burial_depth,burial_depth_sig,burial_depth_flag,resolution_override,resolution_other,patch_file_name,patch_flag,patch_slip_file,patch_slip_flag,ss_rate_bound_flag,ss_rate_bound_min,ss_rate_bound_max,ds_rate_bound_flag,ds_rate_bound_min,ds_rate_bound_max,ts_rate_bound_flag,ts_rate_bound_min,ts_rate_bound_max`
 			}
 		}
 		const directory = await OpenDirectory(directoryStructure)

--- a/src/State/Segment/Segment.ts
+++ b/src/State/Segment/Segment.ts
@@ -24,6 +24,9 @@ export interface Segment {
 	ts_rate: number
 	ts_rate_sig: number
 	ts_rate_flag: number
+	burial_depth: number
+	burial_depth_sig: number
+	burial_depth_flag: number
 	resolution_override: number
 	resolution_other: number
 	patch_file_name: number
@@ -83,6 +86,9 @@ export const fieldNames = [
 	'ts_rate',
 	'ts_rate_sig',
 	'ts_rate_flag',
+	'burial_depth',
+	'burial_depth_sig',
+	'burial_depth_flag',
 	'resolution_override',
 	'resolution_other',
 	'patch_file_name',
@@ -134,6 +140,9 @@ export const defaultSegment: FileSegment = {
 	ts_rate: 0,
 	ts_rate_sig: 0,
 	ts_rate_flag: 0,
+	burial_depth: 0,
+	burial_depth_sig: 0,
+	burial_depth_flag: 0,
 	resolution_override: 0,
 	resolution_other: 0,
 	patch_file_name: -1,


### PR DESCRIPTION
`celeri` still expects `burial_depth*` fields, so I'm re-adding references to them here 