### PR TITLE
Enable new celeri `.block` fields

### DIFF
--- a/celeri_ui.sh
+++ b/celeri_ui.sh
@@ -34,6 +34,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
     open -a '/Applications/Google Chrome.app' http://localhost:3000/
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     xdg-open http://localhost:3000/
+elif [[ "$OSTYPE" == "msys"* ]]; then 
+	START "Chrome" "C:\Program Files\Google\Chrome\Application\chrome.exe" http://localhost:3000/
 fi
 
 echo "Celeri UI is running at http://localhost:3000/"

--- a/mocha/tests/FileOpenerTests.spec.ts
+++ b/mocha/tests/FileOpenerTests.spec.ts
@@ -156,8 +156,8 @@ BRb                                                                ,245.927,44.7
 	it('Can Open Block Files Properly', async () => {
 		const directoryStructure = {
 			root: {
-				'block.csv': `other1,other2,other3,other4,other5,other6,name,interior_lon,interior_lat,euler_lon,euler_lon_sig,euler_lat,euler_lat_sig,rotation_rate,rotation_rate_sig,rotation_flag,apriori_flag,strain_rate,strain_rate_sig,strain_rate_flag
-0,0,0,0,0,0,"ele56         ",245.241,39.099,65.697,2.71,-49.701,2.084,0.222,0.013, 0, 0, 0, 0, 0`
+				'block.csv': `other1,other2,other3,other4,other5,other6,name,interior_lon,interior_lat,euler_lon,euler_lon_sig,euler_lat,euler_lat_sig,rotation_rate,rotation_rate_sig,rotation_flag,apriori_flag,strain_rate,strain_rate_sig,strain_rate_flag,area_steradians,area_plate_carree,block_label,euler_lon_err,euler_lat_err,euler_rate,euler_rate_err,rotation_rms_velocity_flag_sigma
+0,0,0,0,0,0,"ele56         ",245.2410,39.0990,61.3073,2.7100,-59.3376,2.0840,0.2220,0.0130,0,0,0,0,0,0.7651,3696.4372,1,0.0000,0.0000,0.0927,0.0000,0.0000`
 			}
 		}
 		const directory = await OpenDirectory(directoryStructure)
@@ -175,7 +175,7 @@ BRb                                                                ,245.927,44.7
 	it('Can Write Block Files Properly', async () => {
 		const directoryStructure = {
 			root: {
-				'block.csv': `other1,other2,other3,other4,other5,other6,name,interior_lon,interior_lat,euler_lon,euler_lon_sig,euler_lat,euler_lat_sig,rotation_rate,rotation_rate_sig,rotation_flag,apriori_flag,strain_rate,strain_rate_sig,strain_rate_flag`
+				'block.csv': `other1,other2,other3,other4,other5,other6,name,interior_lon,interior_lat,euler_lon,euler_lon_sig,euler_lat,euler_lat_sig,rotation_rate,rotation_rate_sig,rotation_flag,apriori_flag,strain_rate,strain_rate_sig,strain_rate_flag,area_steradians,area_plate_carree,block_label,euler_lon_err,euler_lat_err,euler_rate,euler_rate_err,rotation_rms_velocity_flag_sigma`
 			}
 		}
 		const directory = await OpenDirectory(directoryStructure)
@@ -527,8 +527,8 @@ $EndElements`
 					'segment_file_name.csv': `name,lon1,lat1,lon2,lat2,dip,res,other3,other6,other7,other8,other9,other10,other11,create_ribbon_mesh,locking_depth,locking_depth_sig,locking_depth_flag,dip_sig,dip_flag,ss_rate,ss_rate_sig,ss_rate_flag,ds_rate,ds_rate_sig,ds_rate_flag,ts_rate,ts_rate_sig,ts_rate_flag,resolution_override,resolution_other,mesh_file_index,mesh_flag,patch_slip_file,patch_slip_flag,ss_rate_bound_flag,ss_rate_bound_min,ss_rate_bound_max,ds_rate_bound_flag,ds_rate_bound_min,ds_rate_bound_max,ts_rate_bound_flag,ts_rate_bound_min,ts_rate_bound_max,
 				BRa                                                                ,247.087,43.873,247.764,42.286,90,100,0,0,0,0,0,0,0,0,15,5,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1.0,1.0,0,-1.0,1.0,0,-1.0,1.0,
 				BRb                                                                ,245.927,44.722,247.087,43.873,90,100,0,0,0,0,0,0,0,0,15,5,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1.0,1.0,0,-1.0,1.0,0,-1.0,1.0,`,
-					'block_file_name.csv': `other1,other2,other3,other4,other5,other6,name,interior_lon,interior_lat,euler_lon,euler_lon_sig,euler_lat,euler_lat_sig,rotation_rate,rotation_rate_sig,rotation_flag,apriori_flag,strain_rate,strain_rate_sig,strain_rate_flag
-				0,0,0,0,0,0,"ele56         ",245.241,39.099,65.697,2.71,-49.701,2.084,0.222,0.013, 0, 0, 0, 0, 0`,
+					'block_file_name.csv': `other1,other2,other3,other4,other5,other6,name,interior_lon,interior_lat,euler_lon,euler_lon_sig,euler_lat,euler_lat_sig,rotation_rate,rotation_rate_sig,rotation_flag,apriori_flag,strain_rate,strain_rate_sig,strain_rate_flag,area_steradians,area_plate_carree,block_label,euler_lon_err,euler_lat_err,euler_rate,euler_rate_err,rotation_rms_velocity_flag_sigma
+0,0,0,0,0,0,"ele56         ",245.2410,39.0990,61.3073,2.7100,-59.3376,2.0840,0.2220,0.0130,0,0,0,0,0,0.7651,3696.4372,1,0.0000,0.0000,0.0927,0.0000,0.0000`,
 					'station_file_name.csv': `lon,lat,corr,other1,name,east_vel,north_vel,east_sig,north_sig,flag,up_vel,up_sig,east_adjust,north_adjust,up_adjust,
 				183.434,-43.956,0.205,3,"BRAE_GPS",-38.713,50.072,0.461,0.48,1,0,1,0,0,0,`
 				},

--- a/src/State/Block/Block.ts
+++ b/src/State/Block/Block.ts
@@ -19,6 +19,14 @@ export interface Block {
 	strain_rate: number
 	strain_rate_sig: number
 	strain_rate_flag: number
+	area_steradians: number
+	area_plate_carree: number
+	block_label: number
+	euler_lon_err: number
+	euler_lat_err: number
+	euler_rate: number
+	euler_rate_err: number
+	rotation_rms_velocity_flag_sigma: number
 }
 
 export const fieldNames = [
@@ -41,7 +49,15 @@ export const fieldNames = [
 	'apriori_flag',
 	'strain_rate',
 	'strain_rate_sig',
-	'strain_rate_flag'
+	'strain_rate_flag',
+	'area_steradians',
+	'area_plate_carree',
+	'block_label',
+	'euler_lon_err',
+	'euler_lat_err',
+	'euler_rate',
+	'euler_rate_err',
+	'rotation_rms_velocity_flag_sigma'
 ]
 
 export const defaultBlock: Block = {
@@ -55,16 +71,24 @@ export const defaultBlock: Block = {
 	interior_lon: 0,
 	interior_lat: 0,
 	euler_lon: 0,
-	euler_lon_sig: 0,
+	euler_lon_sig: 1,
 	euler_lat: 0,
-	euler_lat_sig: 0,
+	euler_lat_sig: 1,
 	rotation_rate: 0,
-	rotation_rate_sig: 0,
+	rotation_rate_sig: 1,
 	rotation_flag: 0,
 	apriori_flag: 0,
 	strain_rate: 0,
-	strain_rate_sig: 0,
-	strain_rate_flag: 0
+	strain_rate_sig: 1,
+	strain_rate_flag: 0,
+	area_steradians: 0,
+	area_plate_carree: 0,
+	block_label: 0,
+	euler_lon_err: 1,
+	euler_lat_err: 1,
+	euler_rate: 0,
+	euler_rate_err: 1,
+	rotation_rms_velocity_flag_sigma: 1
 }
 
 export function createBlock(partial?: Partial<Block>): Block {


### PR DESCRIPTION
This PR adds new fields to the handling of `.block` files used by current versions of `celeri`, including: 

`euler_lon_err`, `euler_lat_err`, `euler_rate` ,`euler_rate_err`, and `rotation_rms_velocity_flag_sigma`

The latter parameter has a global option specified in the `.config`, but it can be set for individual blocks using this field of the `.block` file. 